### PR TITLE
JobsOptions extension to load CronJobRegistry from a assembly

### DIFF
--- a/samples/Basic/Startup.cs
+++ b/samples/Basic/Startup.cs
@@ -37,6 +37,9 @@ namespace Basic
 				// Use the cron jobs registry
 				options.UseCronJobRegistry<BasicCronJobRegistry>();
 
+				// or load from an assembly
+				//options.UseCronJobRegistries(typeof(Startup).Assembly);
+
 				// Configure the polling delay used when polling the storage (in seconds)
 				options.PollingDelay = 10;
 			});

--- a/src/MR.AspNetCore.Jobs/JobsOptionsExtensions.cs
+++ b/src/MR.AspNetCore.Jobs/JobsOptionsExtensions.cs
@@ -1,0 +1,41 @@
+﻿using MR.AspNetCore.Jobs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+	public static class JobsOptionsExtensions
+	{
+		/// <summary>
+		/// Registers the cron jobs registries within the assembly
+		/// </summary>
+		/// <param name="assembly">Assembly containing classes extending from <see cref="CronJobRegistry"/>.</param>
+		public static void UseCronJobRegistries(this JobsOptions jobsOptions, Assembly assembly)
+		{
+			// get all classes extending cron job registry
+			var types = assembly.GetTypes()
+				.Where(type => typeof(CronJobRegistry)
+				.IsAssignableFrom(type));
+
+			foreach (var type in types)
+			{
+				var registry = Activator.CreateInstance(type) as CronJobRegistry;
+				jobsOptions.UseCronJobRegistry(registry);
+			}
+		}
+
+		/// <summary>
+		/// Registers the cron jobs registries within the assembly
+		/// </summary>
+		/// <param name="assemblies">Assembly containing classes extending from <see cref="CronJobRegistry"/>.</param>
+		public static void UseCronJobRegistries(this JobsOptions jobsOptions, IEnumerable<Assembly> assemblies)
+		{
+			foreach (var assembly in assemblies)
+			{
+				jobsOptions.UseCronJobRegistries(assembly);
+			}
+		}
+	}
+}

--- a/src/MR.AspNetCore.Jobs/JobsOptionsExtensions.cs
+++ b/src/MR.AspNetCore.Jobs/JobsOptionsExtensions.cs
@@ -14,10 +14,8 @@ namespace Microsoft.Extensions.DependencyInjection
 		/// <param name="assembly">Assembly containing classes extending from <see cref="CronJobRegistry"/>.</param>
 		public static void UseCronJobRegistries(this JobsOptions jobsOptions, Assembly assembly)
 		{
-			// get all classes extending cron job registry
-			var types = assembly.GetTypes()
-				.Where(type => typeof(CronJobRegistry)
-				.IsAssignableFrom(type));
+			// Get all classes extending cron job registry
+			var types = assembly.GetTypes().Where(type => typeof(CronJobRegistry).IsAssignableFrom(type));
 
 			foreach (var type in types)
 			{


### PR DESCRIPTION
JobsOptions extension to allow scanning an assembly for classes extending CronJobRegistry and register them.